### PR TITLE
chore(deps): upgrade Rsbuild Vue 2 JSX dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
-    "@rsbuild/core": "^2.1.2",
-    "@rsbuild/plugin-vue2": "^1.1.2",
+    "@rsbuild/core": "^2.1.3",
+    "@rsbuild/plugin-vue2": "^1.2.0",
     "@rslib/core": "^0.23.1",
     "@rslint/core": "^0.6.4",
     "@types/node": "^24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@2.1.2)
+        version: 1.2.1(@rsbuild/core@2.1.3)
       '@vue/babel-preset-jsx':
         specifier: ^1.4.0
         version: 1.4.0(@babel/core@7.29.0)(vue@2.7.16)
@@ -19,11 +19,11 @@ importers:
         specifier: ^1.61.1
         version: 1.61.1
       '@rsbuild/core':
-        specifier: ^2.1.2
-        version: 2.1.2
+        specifier: ^2.1.3
+        version: 2.1.3
       '@rsbuild/plugin-vue2':
-        specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.2)(css-loader@7.1.2(webpack@5.107.2(postcss@8.4.38)))(postcss@8.4.38)(prettier@3.9.4)
+        specifier: ^1.2.0
+        version: 1.2.0(@rsbuild/core@2.1.3)(css-loader@7.1.2(webpack@5.108.3(postcss@8.4.38)))(postcss@8.4.38)(prettier@3.9.4)
       '@rslib/core':
         specifier: ^0.23.1
         version: 0.23.1(typescript@6.0.3)
@@ -393,6 +393,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.1.3':
+    resolution: {integrity: sha512-R2W+eiuPZhUKU2EGyAtUeJMe8LTvyUKbAKTZRfLoZPbSWslMq4t9wLrJY7xVTB/qlUyRl1d/MeP7otvp1HGapA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.2.1':
     resolution: {integrity: sha512-6Zad7Ff/RUNc91AtftemJcJ1wcZRGOiwuJy349qlLJl9F++oRYwUhx+MxLSpNnVeIywWx2mKdZZBtD1hLqfj9w==}
     peerDependencies:
@@ -401,10 +411,10 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-vue2@1.1.2':
-    resolution: {integrity: sha512-BgFiriAvPGeMNUnAPlJf0U4UjdDx8FpcdYQ2dG8yO7znJlRLu++D9KQGMp/Fo2QeFBQiVuK2uq16aeNjqIyxmg==}
+  '@rsbuild/plugin-vue2@1.2.0':
+    resolution: {integrity: sha512-M0YWGOGZKV6oz7qV5Q/BB+qitQEtqKhv3wy0RqQYEqLzMgPvVwW8sZvxOFLxDAa150C6+TYv99aAKkgVznE8aA==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@rsbuild/core': ^1.0.0 || ^2.0.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -951,8 +961,8 @@ packages:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
 
-  enhanced-resolve@5.22.1:
-    resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
+  enhanced-resolve@5.24.1:
+    resolution: {integrity: sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==}
     engines: {node: '>=10.13.0'}
 
   es-module-lexer@2.1.0:
@@ -996,9 +1006,6 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1073,6 +1080,49 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minimizer-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -1222,49 +1272,6 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  terser-webpack-plugin@5.6.1:
-    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@minify-html/node': '*'
-      '@swc/core': '*'
-      '@swc/css': '*'
-      '@swc/html': '*'
-      clean-css: '*'
-      cssnano: '*'
-      csso: '*'
-      esbuild: '*'
-      html-minifier-terser: '*'
-      lightningcss: '*'
-      postcss: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@minify-html/node':
-        optional: true
-      '@swc/core':
-        optional: true
-      '@swc/css':
-        optional: true
-      '@swc/html':
-        optional: true
-      clean-css:
-        optional: true
-      cssnano:
-        optional: true
-      csso:
-        optional: true
-      esbuild:
-        optional: true
-      html-minifier-terser:
-        optional: true
-      lightningcss:
-        optional: true
-      postcss:
-        optional: true
-      uglify-js:
-        optional: true
-
   terser@5.31.6:
     resolution: {integrity: sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==}
     engines: {node: '>=10'}
@@ -1322,16 +1329,16 @@ packages:
     resolution: {integrity: sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==}
     deprecated: Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.
 
-  watchpack@2.5.1:
-    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
 
-  webpack@5.107.2:
-    resolution: {integrity: sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==}
+  webpack@5.108.3:
+    resolution: {integrity: sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -1762,7 +1769,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.2)':
+  '@rsbuild/core@2.1.3':
+    dependencies:
+      '@rspack/core': 2.1.2(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -1771,16 +1785,16 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.2
+      '@rsbuild/core': 2.1.3
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-vue2@1.1.2(@rsbuild/core@2.1.2)(css-loader@7.1.2(webpack@5.107.2(postcss@8.4.38)))(postcss@8.4.38)(prettier@3.9.4)':
+  '@rsbuild/plugin-vue2@1.2.0(@rsbuild/core@2.1.3)(css-loader@7.1.2(webpack@5.108.3(postcss@8.4.38)))(postcss@8.4.38)(prettier@3.9.4)':
     dependencies:
-      vue-loader: 15.11.1(css-loader@7.1.2(webpack@5.107.2(postcss@8.4.38)))(prettier@3.9.4)(webpack@5.107.2(postcss@8.4.38))
-      webpack: 5.107.2(postcss@8.4.38)
+      vue-loader: 15.11.1(css-loader@7.1.2(webpack@5.108.3(postcss@8.4.38)))(prettier@3.9.4)(webpack@5.108.3(postcss@8.4.38))
+      webpack: 5.108.3(postcss@8.4.38)
     optionalDependencies:
-      '@rsbuild/core': 2.1.2
+      '@rsbuild/core': 2.1.3
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -2279,7 +2293,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  css-loader@7.1.2(webpack@5.107.2(postcss@8.4.38)):
+  css-loader@7.1.2(webpack@5.108.3(postcss@8.4.38)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -2290,7 +2304,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.107.2(postcss@8.4.38)
+      webpack: 5.108.3(postcss@8.4.38)
 
   cssesc@3.0.0: {}
 
@@ -2304,7 +2318,7 @@ snapshots:
 
   emojis-list@3.0.0: {}
 
-  enhanced-resolve@5.22.1:
+  enhanced-resolve@5.24.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -2336,8 +2350,6 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
-
-  glob-to-regexp@0.4.1: {}
 
   graceful-fs@4.2.11: {}
 
@@ -2397,6 +2409,16 @@ snapshots:
   mime-db@1.54.0: {}
 
   minimist@1.2.8: {}
+
+  minimizer-webpack-plugin@5.6.1(postcss@8.4.38)(webpack@5.108.3(postcss@8.4.38)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.31.6
+      webpack: 5.108.3(postcss@8.4.38)
+    optionalDependencies:
+      postcss: 8.4.38
 
   ms@2.1.2: {}
 
@@ -2507,16 +2529,6 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(postcss@8.4.38)(webpack@5.107.2(postcss@8.4.38)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.31.6
-      webpack: 5.107.2(postcss@8.4.38)
-    optionalDependencies:
-      postcss: 8.4.38
-
   terser@5.31.6:
     dependencies:
       '@jridgewell/source-map': 0.3.6
@@ -2540,15 +2552,15 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(css-loader@7.1.2(webpack@5.107.2(postcss@8.4.38)))(prettier@3.9.4)(webpack@5.107.2(postcss@8.4.38)):
+  vue-loader@15.11.1(css-loader@7.1.2(webpack@5.108.3(postcss@8.4.38)))(prettier@3.9.4)(webpack@5.108.3(postcss@8.4.38)):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0
-      css-loader: 7.1.2(webpack@5.107.2(postcss@8.4.38))
+      css-loader: 7.1.2(webpack@5.108.3(postcss@8.4.38))
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      webpack: 5.107.2(postcss@8.4.38)
+      webpack: 5.108.3(postcss@8.4.38)
     optionalDependencies:
       prettier: 3.9.4
     transitivePeerDependencies:
@@ -2618,14 +2630,13 @@ snapshots:
       '@vue/compiler-sfc': 2.7.16
       csstype: 3.1.3
 
-  watchpack@2.5.1:
+  watchpack@2.5.2:
     dependencies:
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.107.2(postcss@8.4.38):
+  webpack@5.108.3(postcss@8.4.38):
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
@@ -2636,19 +2647,18 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.22.1
+      enhanced-resolve: 5.24.1
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(postcss@8.4.38)(webpack@5.108.3(postcss@8.4.38))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(postcss@8.4.38)(webpack@5.107.2(postcss@8.4.38))
-      watchpack: 2.5.1
+      watchpack: 2.5.2
       webpack-sources: 3.5.0
     transitivePeerDependencies:
       - '@minify-html/node'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 allowBuilds:
   core-js: false
   simple-git-hooks: false
+minimumReleaseAgeExclude:
+  - '@rsbuild/core'
+  - '@rsbuild/plugin-*'


### PR DESCRIPTION
## Summary

This PR upgrades the Vue 2 JSX plugin test dependencies to use `@rsbuild/core@^2.1.3` and `@rsbuild/plugin-vue2@^1.2.0`. It picks up the published Vue 2 plugin fix for Rsbuild import-attribute rules and keeps the JSX plugin test setup aligned with the Vue 2 plugin release.

## Testing

- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`