### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@rsbuild/plugin-vue2": "^1.2.0",
     "@rslib/core": "^0.23.1",
     "@rslint/core": "^0.6.4",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.11.1",
     "@rstest/playwright": "^0.11.1",
     "@types/node": "^24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.11.1
         version: 0.11.1
@@ -652,6 +655,9 @@ packages:
         optional: true
       '@swc/helpers':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.11.1':
     resolution: {integrity: sha512-9iJnDrM/zYuHyk1//CMr/Jer2XughgN3fYagGb1YWpMLUke+E+WXlUPgACwf7OkmIB47/TttbLFK+4zwGDNOFg==}
@@ -2278,6 +2284,8 @@ snapshots:
       '@rspack/binding': 2.1.3
     optionalDependencies:
       '@swc/helpers': 0.5.23
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.11.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
+  - '@rstackjs/test-utils@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,1 +1,0 @@
-export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,14 +1,1 @@
-const portMap = new Map();
-
-export function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 30000) + 15000,
-) {
-  let port = defaultPort;
-  while (true) {
-    if (!portMap.get(port)) {
-      portMap.set(port, 1);
-      return port;
-    }
-    port++;
-  }
-}
+export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/jsx-basic/rsbuild.config.ts
+++ b/test/jsx-basic/rsbuild.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/jsx-basic/rsbuild.config.ts
+++ b/test/jsx-basic/rsbuild.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 import { pluginVue2Jsx } from '../../dist';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [

--- a/test/sfc-lang-jsx/rsbuild.config.ts
+++ b/test/sfc-lang-jsx/rsbuild.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-lang-jsx/rsbuild.config.ts
+++ b/test/sfc-lang-jsx/rsbuild.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 import { pluginVue2Jsx } from '@rsbuild/plugin-vue2-jsx';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [

--- a/test/sfc-lang-tsx/rsbuild.config.ts
+++ b/test/sfc-lang-tsx/rsbuild.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-lang-tsx/rsbuild.config.ts
+++ b/test/sfc-lang-tsx/rsbuild.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 import { pluginVue2Jsx } from '@rsbuild/plugin-vue2-jsx';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
This PR replaces the local random-port helper with `@rstackjs/test-utils` so test servers verify port availability through the shared ecosystem implementation. Rsbuild configs now await the asynchronous helper.